### PR TITLE
Simplify keyboard shortcuts to avoid combo key presses

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -1418,14 +1418,15 @@ static bool handle_key(SDLKey key, SDLMod mod)
         return true;
 
     } else if (key == SDLK_TAB) {
-        if (mod & KMOD_CTRL) {
-            if (mod & KMOD_SHIFT)
-                selector_rescan(sel);
-            else
-                selector_toggle_order(sel);
-        } else {
-            selector_toggle(sel);
-        }
+        selector_toggle(sel);
+        return true;
+
+    } else if (key == SDLK_LCTRL) {
+        selector_rescan(sel);
+        return true;
+
+    } else if (key == SDLK_LALT) {
+        selector_toggle_order(sel);
         return true;
 
     } else if ((key == SDLK_EQUALS) || (key == SDLK_PLUS)) {

--- a/interface.c
+++ b/interface.c
@@ -1425,7 +1425,7 @@ static bool handle_key(SDLKey key, SDLMod mod)
         selector_rescan(sel);
         return true;
 
-    } else if (key == SDLK_LALT) {
+    } else if (key == SDLK_LSHIFT) {
         selector_toggle_order(sel);
         return true;
 

--- a/xwax.1
+++ b/xwax.1
@@ -154,8 +154,7 @@ The playback of each deck (direction, speed and position) is
 controlled via the incoming timecode signal from the turntables.
 The keyboard provides additional controls.
 .P
-"C-" and "S-" means a keypress is combined with
-the 'Control' or 'Shift' key, respectively.
+"C-" means a keypress is combined with the 'Control' or 'Ctrl' key.
 .P
 Record selection controls:
 .TP
@@ -171,12 +170,12 @@ Switch to the previous/next crate of records.
 tab
 Toggle between the current crate and the 'All records' crate.
 .TP
-C-tab
+left alt
 Toggle sort mode between: artist/track name, BPM and 'playlist'
 order. Playlist order is the order in which records were returned
 from the scanner.
 .TP
-C-S-tab
+left ctrl
 Re-scan the currently selected crate.
 .P
 To filter the current list of records type a portion of a record

--- a/xwax.1
+++ b/xwax.1
@@ -170,7 +170,7 @@ Switch to the previous/next crate of records.
 tab
 Toggle between the current crate and the 'All records' crate.
 .TP
-left alt
+left shift
 Toggle sort mode between: artist/track name, BPM and 'playlist'
 order. Playlist order is the order in which records were returned
 from the scanner.


### PR DESCRIPTION
This replaces pull request #1 from danielhjames.

danielhjames: This avoids having to make a three-finger combo to rescan the crate, or a two-finger combo to toggle sort mode. It's simply left control key for rescan and left alt to toggle sort mode, which sit nicely with the existing tab key for toggling 'All records'.

lpil: I would prefer not to use alt. As applications tend not to just alt I've been able to use alt for window manager hotkeys without it conflicting with other applications.

danielhjames: Hi Louis, since xwax search does not accept upper case input, the left shift key works just as well as left alt for toggling the sort order. I've updated the pull request.

Sorry for messing up the last pull request.

Cheers!
