### PR TITLE
Set LC_NUMERIC=C for string to float conversions

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <iconv.h>
+#include <locale.h>
 #include <math.h>
 #include <pthread.h>
 #include <stdbool.h>
@@ -1803,7 +1804,9 @@ static int parse_geometry(const char *s)
         return -1;
     }
 
+    setlocale(LC_NUMERIC, "C");
     n = sscanf(s, "/%f%n", &scale, &len);
+    setlocale(LC_NUMERIC, "");
     switch (n) {
     case EOF:
         return 0;

--- a/interface.c
+++ b/interface.c
@@ -1804,7 +1804,10 @@ static int parse_geometry(const char *s)
         return -1;
     }
 
-    setlocale(LC_NUMERIC, "C");
+    setlocale(LC_NUMERIC, "C"); /* Use '.' as default decimal delimiter,
+                                 * so we always expect '1.5' (default in
+                                 * C locale) and not e.g. '1,5' (in de_DE).
+                                 */
     n = sscanf(s, "/%f%n", &scale, &len);
     setlocale(LC_NUMERIC, "");
     switch (n) {

--- a/library.c
+++ b/library.c
@@ -437,7 +437,10 @@ static double parse_bpm(const char *s)
         return 0.0;
 
     errno = 0;
-    setlocale(LC_NUMERIC, "C");
+    setlocale(LC_NUMERIC, "C"); /* Use '.' as default decimal delimiter,
+                                 * so we always expect '100.0' (default in
+                                 * C locale) and not e.g. '100,0' (in de_DE).
+                                 */
     bpm = strtod(s, &endptr);
     setlocale(LC_NUMERIC, "");
     if (errno == ERANGE || *endptr != '\0' || !isfinite(bpm) || bpm <= 0.0)

--- a/library.c
+++ b/library.c
@@ -22,6 +22,7 @@
 #include <errno.h>
 #include <iconv.h>
 #include <libgen.h> /*  basename() */
+#include <locale.h>
 #include <math.h> /* isfinite() */
 #include <stdbool.h>
 #include <stdio.h>
@@ -436,7 +437,9 @@ static double parse_bpm(const char *s)
         return 0.0;
 
     errno = 0;
+    setlocale(LC_NUMERIC, "C");
     bpm = strtod(s, &endptr);
+    setlocale(LC_NUMERIC, "");
     if (errno == ERANGE || *endptr != '\0' || !isfinite(bpm) || bpm <= 0.0)
         return INFINITY;
 


### PR DESCRIPTION
As discussed in the threads
- "Window geometry ('1920x1080/1.5') is not valid" and
- "Ignoring malformed BPM"

in October (https://sourceforge.net/p/xwax/mailman/xwax-devel/?viewmonth=201810) it makes sense to default to the standard decimal delimiter `"."` for the

- zoom factor in the `"-g"` (geometry) option, e.g `"1.5"` and
- BPM values of the particular media files, e.g `"100.0 BPM"`

Set `LC_NUMERIC=C` for the string to float operations.
