### PR TITLE
Display live bpm with current pitch update

### DIFF
--- a/interface.c
+++ b/interface.c
@@ -630,6 +630,33 @@ static void draw_bpm(SDL_Surface *surface, const struct rect *rect, double bpm,
     draw_token(surface, rect, buf, text_col, hsv(h, 1.0, 0.3), bg_col);
 }
 
+static void draw_bpm_live(SDL_Surface *surface, const struct rect *rect, double bpm,
+                     double bpm_live, SDL_Color bg_col)
+{
+    static const double min = 60.0, max = 240.0;
+    char buf[32];
+    double f, h;
+
+    sprintf(buf, "%5.1f > %5.1f", bpm, bpm_live);
+
+    /* Safety catch against bad BPM values, NaN, infinity etc. */
+
+    if (bpm < min || bpm > max || bpm_live < min || bpm_live > max) {
+        draw_token(surface, rect, buf, detail_col, bg_col, bg_col);
+        return;
+    }
+
+    /* Colour compatible BPMs the same; cycle 360 degrees
+     * every time the BPM doubles */
+
+    f = log2(bpm_live);
+    f -= floor(f);
+    h = f * 360.0; /* degrees */
+
+    draw_token(surface, rect, buf, text_col, hsv(h, 1.0, 0.3), bg_col);
+}
+
+
 /*
  * Draw the BPM field, or a gap
  */
@@ -648,9 +675,12 @@ static void draw_bpm_field(SDL_Surface *surface, const struct rect *rect,
  */
 
 static void draw_record(SDL_Surface *surface, const struct rect *rect,
-                        const struct record *record)
+                        const struct deck *deck)
 {
     struct rect artist, title, left, right;
+    const struct record *record = deck->record;
+    double spitch = deck->player.pitch * deck->player.sync_pitch;
+    double live = record->bpm * spitch;
 
     split(*rect, from_top(BIG_FONT_SPACE, 0), &artist, &title);
     draw_text_in_locale(surface, &artist, record->artist,
@@ -659,8 +689,8 @@ static void draw_record(SDL_Surface *surface, const struct rect *rect,
     /* Layout changes slightly if BPM is known */
 
     if (show_bpm(record->bpm)) {
-        split(title, from_left(BPM_WIDTH, 0), &left, &right);
-        draw_bpm(surface, &left, record->bpm, background_col);
+        split(title, from_left(BPM_WIDTH * 2.4, 0), &left, &right);
+        draw_bpm_live(surface, &left, record->bpm, live, background_col);
 
         split(right, from_left(HALF_SPACER, 0), &left, &title);
         draw_rect(surface, &left, background_col);
@@ -1079,7 +1109,7 @@ static void draw_deck(SDL_Surface *surface, const struct rect *rect,
     if (rest.h < 160)
         rest = *rect;
     else
-        draw_record(surface, &track, deck->record);
+        draw_record(surface, &track, deck);
 
     split(rest, from_top(CLOCK_FONT_SIZE * 2, SPACER), &top, &lower);
     if (lower.h < 64)


### PR DESCRIPTION
When BPM is available, on top of the deck, where the BPM is displayed as usual, add next to it the live BPM (initial BPM multiplied by the current pitch) to get estimation of the live BPM.